### PR TITLE
fix allow color font

### DIFF
--- a/drw.c
+++ b/drw.c
@@ -339,7 +339,6 @@ drw_text(Drw *drw, int x, int y, unsigned int w, unsigned int h, unsigned int lp
 			fcpattern = FcPatternDuplicate(drw->fonts->pattern);
 			FcPatternAddCharSet(fcpattern, FC_CHARSET, fccharset);
 			FcPatternAddBool(fcpattern, FC_SCALABLE, FcTrue);
-			FcPatternAddBool(fcpattern, FC_COLOR, FcFalse);
 
 			FcConfigSubstitute(NULL, fcpattern, FcMatchPattern);
 			FcDefaultSubstitute(fcpattern);


### PR DESCRIPTION
when I was trying to figure out which patches you use on your dmenu i found that you have some leftover code from [allow-color-font patch](https://tools.suckless.org/dmenu/patches/allow-color-font/dmenu-allow-color-font-5.0.diff)  ... this line was supposed to be removed with it