### PR TITLE
Install to ${HOME}/.local instead of /usr/local.

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -2,7 +2,7 @@
 VERSION = 5.0
 
 # paths
-PREFIX = /usr/local
+PREFIX = ${HOME}/.local
 MANPREFIX = $(PREFIX)/share/man
 
 X11INC = /usr/X11R6/include


### PR DESCRIPTION
Rationale:
- Private config.h settings do not spill to other users on multi-user systems
- No more sudo make install